### PR TITLE
bugfix: converted gco pointer to integer

### DIFF
--- a/luajit21.py
+++ b/luajit21.py
@@ -2915,7 +2915,7 @@ class lgcpath(lgcstat):
         # print the size of last GC object in the path
         gco = self.gc_path[-1].cast(typ("GCobj*"))
         sz = self.get_obj_sz(g, gco)
-        out("sz:%d (GCobj*)%#x ->END\n" % (sz, gco))
+        out("sz:%d (GCobj*)%#x ->END\n" % (sz, ptr2int(gco)))
 
     def is_intersted_ty(self, ty):
         if not self.obj_ty:


### PR DESCRIPTION
Some version of GDB doesn't convert it automatically.
May fix #18 